### PR TITLE
Use Publish 0.8.0 in CI to generate Output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: macos-latest
+    runs-on: macOS-11
 
     steps:
     - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup JohnSundell/Publish
       run: |
         cd ${HOME}
-        export PUBLISH_VERSION="0.7.0"
+        export PUBLISH_VERSION="0.8.0"
         git clone https://github.com/JohnSundell/Publish.git
         cd ./Publish && git checkout ${PUBLISH_VERSION}
         mv ~/Publish_build .build || true


### PR DESCRIPTION
When Xcode 12.5 is available on CI, the new version from Publish can be used. 

The new Publish version needs Swift 5.4 toolchain which is only available on Xcode 12.5 which is only available on macOS 11 which is transited to private preview.

https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md