### PR TITLE
Fix text overflow in h1 elements

### DIFF
--- a/Resources/styles.css
+++ b/Resources/styles.css
@@ -140,6 +140,7 @@ header nav li a.selected {
 h1 {
 	font-size: 300%;
 	margin-bottom: 20px;
+	overflow-wrap: anywhere;
 }
 
 h2 {


### PR DESCRIPTION
h1-tag Text goes beyond 100% width. 

![Bildschirmfoto 2022-09-18 um 12 11 00](https://user-images.githubusercontent.com/62543867/190897023-f1d01501-9abc-4abc-9c4b-e79dc2ce87b7.png)

Added overflow-wrap: anywhere to fix this issue

![Bildschirmfoto 2022-09-18 um 12 11 12](https://user-images.githubusercontent.com/62543867/190897040-1a357c5d-fc39-42f0-87e2-465869b7cf0a.png)
