### PR TITLE
Add a link to your Mastodon profile.

### DIFF
--- a/Sources/HimmelstraeumerinBlog/Theme/Theme+Footer.swift
+++ b/Sources/HimmelstraeumerinBlog/Theme/Theme+Footer.swift
@@ -21,6 +21,8 @@ extension Node where Context == HTML.BodyContext {
 			.p(
 				.linkToTwitter,
 				.separator,
+				.linkToMastodon,
+				.separator,
 				.linkToGithub,
 				.separator,
 				.linkToInstagram,
@@ -58,6 +60,14 @@ private extension Node where Context == HTML.BodyContext {
 			.href("https://twitter.com/felibe444"),
 			.target(.blank),
 			.rel(.noreferrer)
+	)
+	
+	static let linkToMastodon: Self =
+		.a(
+			.text("Mastodon 🐘"),
+			.href("https://iosdev.space/@feli"),
+			.target(.blank),
+			.attribute(named: "rel", value: "me noreferrer")
 	)
 
 	static let linkToGithub: Self =


### PR DESCRIPTION
The "me noreferrer" is important. You link to your website from your mastodon account, by linking back from your site with a "me" rel, you should get your website URL marked as verified on your Mastodon account. That way people can tell this profile IS your true and only profile on Mastodon.

![image](https://user-images.githubusercontent.com/39677/202128846-082aac4f-d167-41a1-9e42-a7f7db2c9a9b.png)
