### PR TITLE
Update DOM to only have one <main> tag

### DIFF
--- a/Sources/HimmelstraeumerinBlog/Theme/Theme+Wrapper.swift
+++ b/Sources/HimmelstraeumerinBlog/Theme/Theme+Wrapper.swift
@@ -10,7 +10,7 @@ import Plot
 
 extension Node where Context == HTML.BodyContext {
 	static func wrapper(_ nodes: Node...) -> Node {
-		.main(
+		.div(
 			.class("wrapper"),
 			.group(nodes)
 		)

--- a/Sources/HimmelstraeumerinBlog/Theme/Theme.swift
+++ b/Sources/HimmelstraeumerinBlog/Theme/Theme.swift
@@ -23,7 +23,7 @@ extension Theme where Site == HimmelstraeumerinBlog {
 				.body(
 					.header(for: context, selectedSection: nil),
 					.wrapper(
-						.div(
+						.main(
 							.class("recents"),
 							.h1("Recent Sketchnotes"),
 							try .itemList(


### PR DESCRIPTION
There must not be more than one `<main>` element in a document. 
See https://www.w3schools.com/tags/tag_main.asp 

## Before / After

| Before | After |
|---|---|
| <img width="434" alt="DOM structure with two main tags" src="https://user-images.githubusercontent.com/26111180/222891011-bc9b329f-7343-46a7-b6fd-5aa4c60ea64e.png"> | <img width="430" alt="DOM structure with only one main tag" src="https://user-images.githubusercontent.com/26111180/222891013-6f5011ef-4fd1-4feb-aa1e-d6403b1eb532.png"> |




